### PR TITLE
refacto to more idiomatic code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifndef LIGO
-LIGO=docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:next
+LIGO=docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:stable
 endif
 
 .PHONY: test

--- a/lib/bigarray.mligo
+++ b/lib/bigarray.mligo
@@ -1,187 +1,98 @@
-(**
- * Definition
- *)
-type 'a big_array = 'a list
+let fill (type a) (n : int) (x : a) : a list =
+  let rec aux (n, x, acc : int * a * a list) : a list =
+    if (n = 0) then acc
+    else aux (n - 1, x, x :: acc) in
+  aux (n, x, ([] : a list))
 
-(**
- * Empty constructor
- *)
-[@inline]
-let construct (type kind) (size : nat) (wanted_type : kind) : kind option big_array =
-  let rec construct (size : nat) (wanted_type : kind) (res : kind option big_array) : kind option big_array =
-    if (size = 0n) then res
-    else construct (abs(size-1n)) wanted_type ((None: kind option) :: res) in
-  construct size  wanted_type ([] : kind option big_array)
+let rec last_exn (type a) (xs : a list) : a =
+  match xs with
+    [] -> failwith "Empty list"
+  | [hd] -> hd
+  | _ :: tl -> last_exn tl
 
-(**
- * Last retrieves the last element
- *)
-[@inline]
-let last (type kind) (lst1 : kind big_array) : kind =
-  let rec last (lst1 : kind big_array) : kind =
-    match lst1 with
-    | []        -> failwith "The big_array is empty"
-    | [ head ]  -> head
-    | _ :: tail -> last tail
-  in
-  last (lst1)
+let reverse (type a) (xs : a list) : a list =
+  let f (ys, x : (a list * a)) : a list = x :: ys in
+  List.fold_left f ([] : a list) xs
 
-(**
- * Reversing
- *)
-[@inline]
-let reverse (type kind) (lst1 : kind big_array) : kind big_array =
-  let rec reverse ((lst1, res) : kind big_array * kind big_array) : kind big_array =
-    match lst1 with
-    | [] -> res
-    | hd1 :: tl1 -> reverse (tl1, (hd1 :: res)) in
-  reverse (lst1, ([] : kind big_array))
+let concat (type a) (xs : a list) (ys : a list) : a list =
+  let f (x, ys : (a * a list)) : a list = x :: ys in
+  List.fold_right f xs ys
 
-(**
- * Concatenation
- *)
-[@inline]
-let concat (type kind) (lst1 : kind big_array) (lst2 : kind big_array) : kind big_array =
-  let rec concat ((lst1r, lst2) : kind big_array * kind big_array) : kind big_array =
-    match lst1r with
-    | []         -> lst2
-    | hd1 :: tl1 -> concat (tl1, hd1 :: lst2) in
-  let lst1r : kind big_array = reverse lst1 in
-  concat (lst1r, lst2)
+let get_exn (type a) (xs : a list) (n : int) : a =
+  let rec aux (remaining : a list) (cur : int) : a =
+    match remaining with
+      [] -> failwith "Not found in list"
+    | hd :: tl -> if cur = n then hd else aux tl (cur + 1) in
+  aux xs 0
 
-(**
- * Get an element by his number position
- *)
-[@inline]
-let find (type kind) (position : nat) (lst1 : kind big_array) : kind =
-  let rec get ((position, lst1) : nat * kind big_array) : kind =
-    match lst1 with
-    | []         -> failwith "Position is highter than big_array length"
-    | hd1 :: tl1 ->
-      if (position = 0n) then hd1
-      else get (abs(position - 1n), tl1) in
-  get (position, lst1)
+let set_exn (type a) (xs : a list) (n : int) (x : a) : a list =
+  let rec aux (xs, n, x, acc : a list * int * a * a list)
+  : a list =
+    match xs with
+      [] -> failwith "Not found in list"
+    | hd :: tl ->
+        if (n = 0)
+        then
+          let ys = reverse (x :: acc) in
+          concat ys tl
+        else aux (tl, n - 1, x, hd :: acc) in
+  aux (xs, n, x, ([] : a list))
 
-(**
- * Set an element by his number position
- *)
-[@inline]
-let set (type kind) (element : kind) (position : nat) (lst1 : kind big_array) : kind big_array =
-  let rec set ((element, position, lst1, res) : kind * nat * kind big_array * kind big_array) : kind big_array =
-    match lst1 with
-    | []         -> failwith "Position is highter than big_array length"
-    | hd1 :: tl1 ->
-      if (position = 0n) then
-        let lst2 : kind big_array = reverse (element :: res) in
-        concat lst2 tl1
-      else set (element, abs(position - 1n), tl1, hd1 :: res) in
-  set (element, position, lst1, ([] : kind big_array))
+let insert_exn (type a) (xs : a list) (n : int) (x : a) : a list =
+  let rec aux (xs, n, x, acc : a list * int * a * a list)
+  : a list =
+    match xs with
+      [] -> failwith "Not found in list"
+    | hd :: tl ->
+        if (n = 0)
+        then
+          let ys = reverse (x :: acc) in
+          concat ys xs
+        else aux (tl, n - 1, x, hd :: acc) in
+  aux (xs, n, x, ([] : a list))
 
-(**
- * Insertion
- *)
-[@inline]
-let insert (type kind) (element : kind) (position : nat) (lst1 : kind big_array) : kind big_array =
-  let rec insert ((element, position, lst1, lst2) : kind * nat * kind big_array * kind big_array) : kind big_array =
-    match lst1 with
-    | []         -> failwith "Position is highter than big_array length"
-    | hd1 :: tl1 ->
-      if (position = 0n) then
-        let lst3 : kind big_array = element::lst2 in
-        let lst4 : kind big_array = reverse lst3 in
-        concat lst4 lst1
-      else
-        insert (element, abs(position - 1n), tl1, hd1 :: lst2) in
-  insert (element, position, lst1, ([] : kind big_array))
+let remove_exn (type a) (xs : a list) (n : int) : a list =
+  let rec aux (xs, n, acc : a list * int * a list) : a list =
+    match xs with
+      [] -> failwith "Not found in list"
+      | hd :: tl ->
+        if (n = 0)
+        then
+          let ys = reverse acc in
+          concat ys tl
+        else aux (tl, n - 1, hd :: acc) in
+  aux (xs, n, ([] : a list))
 
-(**
- * Drop the element at a specific position
- *)
-[@inline]
-let drop (type kind) (position : nat) (lst1 : kind big_array) : kind big_array =
-  let rec drop ((position, lst1, lst2) : nat * kind big_array * kind big_array) : kind big_array =
-    match lst1 with
-    | []         -> failwith "Position is highter than big_array length"
-    | hd1 :: tl1 ->
-      if (position = 0n) then
-        let lst3 : kind big_array = reverse lst2 in
-        concat lst3 tl1
-      else
-        drop (abs(position - 1n), tl1, hd1 :: lst2) in
-  drop (position, lst1, ([] : kind big_array))
+let rec drop_exn (type a) (xs : a list) (n : int) : a list =
+  match xs with
+    [] -> failwith "Not found in list"
+  | hd :: tl -> if (n = 0) then xs else drop_exn tl (n - 1)
 
-(**
- * take retrieves first elements
- *)
-[@inline]
-let take (type kind) (i : nat) (lst : kind big_array) : kind big_array =
-  let rec take ((i, lst, res) : nat * kind big_array * kind big_array) : kind big_array =
-    if (i = 0n ) then reverse res
-    else match lst with
-      | []         -> reverse res
-      | hd1 :: tl1 -> take (abs(i-1n), tl1, hd1 :: res) in
-  take (i, lst, ([] : kind big_array))
+let take (type a) (xs : a list) (n : int) : a list =
+  let rec aux (xs, n, acc : a list * int * a list) : a list =
+    if (n = 0)
+    then reverse acc
+    else
+      match xs with
+        [] -> reverse acc
+      | hd :: tl -> aux (tl, n - 1, hd :: acc) in
+  aux (xs, n, ([] : a list))
 
-(**
- * Slice extracts a sub big array at a specifc position (and a specific length)
- *)
-[@inline]
-let slice (type kind) (i : nat) (k : nat) (lst : kind big_array) : kind big_array =
-  let rec slice ((i, k, lst) : nat * nat * kind big_array) : kind big_array =
-    if (i = 0n ) then
-      let extract : nat = abs(k-i) in
-      take extract lst
-    else match lst with
-      | []         -> []
-      | _hd1 :: tl1 -> slice (abs(i-1n), k, tl1) in
-  slice (i, k, lst)
+let slice (type a) (xs : a list) (start : int) (range : int)
+: a list =
+  take (drop_exn xs start) range
 
-(**
- * Split a given big array at a specific position
- *)
-[@inline]
-let split (type kind) (i : nat) (lst : kind big_array) : kind big_array * kind big_array =
-  let rec split ((i, lst1, lst2): nat * kind big_array * kind big_array) : kind big_array * kind big_array =
-    if (i = 0n ) then let lstr = reverse lst2 in (lstr, lst1)
-    else match lst1 with
-      | []         -> let lstr = reverse lst2 in (lstr, lst1)
-      | hd1 :: tl1 -> split (abs(i-1n), tl1, hd1 :: lst2) in
-  split (i, lst, ([] : kind big_array))
+let split (type a) (xs : a list) (n : int) : a list * a list =
+  take xs n, drop_exn xs n
 
-(**
- * Rotate to the left
- *)
-[@inline]
-let rotate (type kind) (i : nat) (lst : kind big_array) : kind big_array =
-  let rec rotate ((i, lst, res) : nat * kind big_array * kind big_array) : kind big_array =
-    if (i = 0n ) then
-      let lstr = reverse res in
-      concat lst lstr
-    else match lst with
-      | []         -> reverse res
-      | hd1 :: tl1 -> rotate (abs(i-1n), tl1, hd1 :: res) in
-  rotate (i, lst, ([] : kind big_array))
-
-(**
-* equal (bytes version)
-* WARNING : Two lambda can be packed equal whereas they are different
-*)
-[@inline]
-let equal (type a) (val_a: a) (val_b: a): bool =
-    (Bytes.pack val_a) = (Bytes.pack val_b)
-
-(**
- * Remove all occurences of a given element
- *)
-[@inline]
-let remove (type kind) (element : kind) (lst : kind big_array) : kind big_array =
-  let rec remove ((element, lst, res) : kind * kind big_array * kind big_array) : kind big_array =
-    match lst with
-      | []         -> reverse res
-      | hd1 :: tl1 ->
-        let is_equal = equal hd1 element in
-        if is_equal then remove (element, tl1, res)
-        else remove (element, tl1, hd1 :: res)
-    in
-  remove (element, lst, ([] : kind big_array))
-
+let rotate (type a) (xs : a list) (n : int) : a list =
+  let rec aux (xs, n, acc : a list * int * a list) : a list =
+    if (n = 0)
+    then
+      let ys = reverse acc in
+      concat xs ys
+    else
+      match xs with
+        [] -> reverse acc
+      | hd :: tl -> aux (tl, n - 1, hd :: acc) in
+  aux (xs, n, ([] : a list))

--- a/test/bigarray.test.mligo
+++ b/test/bigarray.test.mligo
@@ -1,240 +1,237 @@
 #import "../lib/bigarray.mligo" "Bigarray"
 
-type 'a big_array = 'a list
+let test_fill =
+  begin
+    assert (Bigarray.fill 4 10 = [10;10;10;10]);
+    assert (Bigarray.fill 4 "foo" = ["foo"; "foo"; "foo"; "foo"])
+  end
 
-// We need to create a generic entrypoint main that do nothing for compilation purpose
-let main (_action, store : bytes * bytes) : operation big_array * bytes = ([] : operation big_array), store
+let test_last_exn =
+  let xs = [1; 2; 3] in
+  let () = assert (Bigarray.last_exn xs = 3) in
+  let xs = ["foo"; "bar"; "baz"] in
+  assert (Bigarray.last_exn xs = "baz")
 
+let test_reverse =
+  let xs = [1; 2; 3] in
+  let () = assert (Bigarray.reverse xs = [3; 2; 1]) in
+  let xs = ["foo"; "bar"; "baz"] in
+  assert (Bigarray.reverse xs = ["baz"; "bar"; "foo"])
 
-(**
- *  Basic Constructor
- *)
-let test_construct_basic_array_should_work =
-  //Given
-  let size : nat = 3n in
-  let _intended_result : nat option list = [(None: nat option) ; (None: nat option) ; (None: nat option) ] in
-  //when
-  let result = Bigarray.construct size 0n in
-  //Then
-  let () = Test.log ("result : ", result) in "OK"
+let test_concat =
+  let xs = [1; 2; 3] in
+  let ys = [4; 5; 6] in
+  let zs = Bigarray.concat xs ys in
+  let () = assert (zs = [1; 2; 3; 4; 5; 6]) in
+  let xs = ["foo"; "bar"; "baz"] in
+  let ys = ["qux"; "quux"; "corge"] in
+  let zs = Bigarray.concat xs ys in
+  assert
+    (zs = ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"])
 
-(**
- *  Get the last element
- *)
-let test_last_element_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"; "four"] in
-  let intended_result : string = "four" in
-  //when
-  let result = Bigarray.last lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_get_exn =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.get_exn xs 0 = 1);
+    assert (Bigarray.get_exn xs 2 = 3);
+    assert (Bigarray.get_exn xs 5 = 6);
+    assert (Bigarray.get_exn ys 0 = "foo");
+    assert (Bigarray.get_exn ys 2 = "baz");
+    assert (Bigarray.get_exn ys 5 = "corge")
+  end
 
-(**
- *  Reverse
- *)
-let test_reversing_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3] in
-  let intended_result : int big_array = [3; 2; 1] in
-  //when
-  let result = Bigarray.reverse lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_set_exn =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.set_exn xs 0 0 = [0; 2; 3; 4; 5; 6; 7]);
+    assert (Bigarray.set_exn xs 2 33 = [1; 2; 33; 4; 5; 6; 7]);
+    assert (Bigarray.set_exn xs 6 77 = [1; 2; 3; 4; 5; 6; 77]);
+    assert
+      (Bigarray.set_exn ys 0 "garply"
+       = ["garply";
+          "bar";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "grault"]);
+    assert
+      (Bigarray.set_exn ys 2 "waldo"
+       = ["foo";
+          "bar";
+          "waldo";
+          "qux";
+          "quux";
+          "corge";
+          "grault"]);
+    assert
+      (Bigarray.set_exn ys 6 "fred"
+       = ["foo";
+          "bar";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "fred"])
+  end
 
-let test_reversing_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"] in
-  let intended_result : string big_array = ["three"; "two"; "one"] in
-  //when
-  let result = Bigarray.reverse lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_insert_exn =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert
+      (Bigarray.insert_exn xs 0 0 = [0; 1; 2; 3; 4; 5; 6; 7]);
+    assert
+      (Bigarray.insert_exn xs 2 3 = [1; 2; 3; 3; 4; 5; 6; 7]);
+    assert
+      (Bigarray.insert_exn xs 6 8 = [1; 2; 3; 4; 5; 6; 8; 7]);
+    assert
+      (Bigarray.insert_exn ys 0 "garply"
+       = ["garply";
+          "foo";
+          "bar";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "grault"]);
+    assert
+      (Bigarray.insert_exn ys 2 "waldo"
+       = ["foo";
+          "bar";
+          "waldo";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "grault"]);
+    assert
+      (Bigarray.insert_exn ys 6 "fred"
+       = ["foo";
+          "bar";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "fred";
+          "grault"])
+  end
 
-(**
- *  Concatenation
- *)
-let test_concatenation_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3] in
-  let lst2 : int big_array = [4; 5] in
-  let intended_result : int big_array = [1 ; 2 ; 3 ; 4 ; 5] in
-  //when
-  let result = Bigarray.concat lst1 lst2 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_remove_exn =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.remove_exn xs 0 = [2; 3; 4; 5; 6; 7]);
+    assert (Bigarray.remove_exn xs 2 = [1; 2; 4; 5; 6; 7]);
+    assert (Bigarray.remove_exn xs 6 = [1; 2; 3; 4; 5; 6]);
+    assert
+      (Bigarray.remove_exn ys 0
+       = ["bar"; "baz"; "qux"; "quux"; "corge"; "grault"]);
+    assert
+      (Bigarray.remove_exn ys 2
+       = ["foo"; "bar"; "qux"; "quux"; "corge"; "grault"]);
+    assert
+      (Bigarray.remove_exn ys 6
+       = ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"])
+  end
 
-let test_concatenation_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"] in
-  let lst2 : string big_array = ["four"; "five"] in
-  let intended_result : string big_array = ["one"; "two"; "three"; "four"; "five"] in
-  //when
-  let result = Bigarray.concat lst1 lst2 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_drop_exn =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.drop_exn xs 0 = [1; 2; 3; 4; 5; 6; 7]);
+    assert (Bigarray.drop_exn xs 2 = [3; 4; 5; 6; 7]);
+    assert (Bigarray.drop_exn xs 6 = [7]);
+    assert
+      (Bigarray.drop_exn ys 0
+       = ["foo";
+          "bar";
+          "baz";
+          "qux";
+          "quux";
+          "corge";
+          "grault"]);
+    assert
+      (Bigarray.drop_exn ys 2
+       = ["baz"; "qux"; "quux"; "corge"; "grault"]);
+    assert (Bigarray.drop_exn ys 6 = ["grault"])
+  end
 
-(**
- *  Get one element
- *)
-let test_get_element_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 4] in
-  let position : nat = 1n in
-  let intended_result : int = 2 in
-  //when
-  let result = Bigarray.find position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_take =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.take xs 0 = ([] : int list));
+    assert (Bigarray.take xs 2 = [1; 2]);
+    assert (Bigarray.take xs 6 = [1; 2; 3; 4; 5; 6]);
+    assert (Bigarray.take ys 0 = ([] : string list));
+    assert (Bigarray.take ys 2 = ["foo"; "bar"]);
+    assert
+      (Bigarray.take ys 6
+       = ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"])
+  end
 
-let test_get_element_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"; "four"] in
-  let position : nat = 1n in
-  let intended_result : string = "two" in
-  //when
-  let result = Bigarray.find position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_slice =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.slice xs 0 0 = ([] : int list));
+    assert (Bigarray.slice xs 0 2 = [1; 2]);
+    assert (Bigarray.slice xs 3 2 = [4; 5]);
+    assert (Bigarray.slice xs 6 1 = [7]);
+    assert (Bigarray.slice ys 0 0 = ([] : string list));
+    assert (Bigarray.slice ys 0 2 = ["foo"; "bar"]);
+    assert (Bigarray.slice ys 3 2 = ["qux"; "quux"]);
+    assert (Bigarray.slice ys 6 1 = ["grault"])
+  end
 
-(**
- *  Set one element
- *)
-let test_set_element_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 4; 5] in
-  let element : int = 7 in
-  let position : nat = 2n in
-  let intended_result : int big_array = [1; 2; 7; 4; 5] in
-  //when
-  let result = Bigarray.set element position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
+let test_split =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert
+      (Bigarray.split xs 0
+       = (([] : int list), [1; 2; 3; 4; 5; 6; 7]));
+    assert (Bigarray.split xs 3 = ([1; 2; 3], [4; 5; 6; 7]));
+    assert (Bigarray.split xs 5 = ([1; 2; 3; 4; 5], [6; 7]));
+    assert
+      (Bigarray.split ys 0
+       = (([] : string list),
+          ["foo";
+           "bar";
+           "baz";
+           "qux";
+           "quux";
+           "corge";
+           "grault"]));
+    assert
+      (Bigarray.split ys 3
+       = (["foo"; "bar"; "baz"],
+          ["qux"; "quux"; "corge"; "grault"]));
+    assert
+      (Bigarray.split ys 5
+       = (["foo"; "bar"; "baz"; "qux"; "quux"],
+          ["corge"; "grault"]))
+  end
 
-let test_set_element_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"; "four"; "five"] in
-  let element : string = "seven" in
-  let position : nat = 1n in
-  let intended_result : string big_array = ["one"; "seven"; "three"; "four"; "five"] in
-  //when
-  let result = Bigarray.set element position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-(**
- *  Insert one element
- *)
-let test_insertion_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 3; 4] in
-  let element : int = 2 in
-  let position : nat = 1n in
-  let intended_result : int big_array = [1 ; 2 ; 3 ; 4] in
-  //when
-  let result = Bigarray.insert element position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-let test_insertion_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "three"; "four"] in
-  let element : string = "two" in
-  let position : nat = 1n in
-  let intended_result : string big_array = ["one"; "two"; "three"; "four"] in
-  //when
-  let result = Bigarray.insert element position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-(**
- *  Drop one element
- *)
-let test_drop_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 4] in
-  let position : nat = 2n in
-  let intended_result : int big_array = [1 ; 2 ; 4] in
-  //when
-  let result = Bigarray.drop position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-let test_drop_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"; "four"] in
-  let position : nat = 3n in
-  let intended_result : string big_array = ["one"; "two"; "three"] in
-  //when
-  let result = Bigarray.drop position lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-(**
- *  Slice
- *)
-let test_slice_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 4] in
-  let i : nat = 1n in
-  let j : nat = 2n in
-  let intended_result : int big_array = [2 ; 3] in
-  //when
-  let result = Bigarray.slice i j lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-let test_slice_with_string_should_work =
-  //Given
-  let lst1 : string big_array = ["one"; "two"; "three"; "four"] in
-  let i : nat = 0n in
-  let j : nat = 6n in
-  let intended_result : string big_array = ["one"; "two"; "three"; "four"] in
-  //when
-  let result = Bigarray.slice i j lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-(**
- *  Split
- *)
-let test_split_with_int_should_work =
-  //Given
-  let lst : int big_array = [1; 2; 3; 4] in
-  let i : nat = 1n in
-  let intended_result1 : int big_array = [1] in
-  let intended_result2 : int big_array = [2; 3; 4] in
-  //when
-  let result = Bigarray.split i lst in
-  //Then
-  let () = assert (result = (intended_result1, intended_result2)) in "OK"
-
-(**
- *  Rotate
- *)
-let test_rotate_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 4] in
-  let i : nat = 1n in
-  let intended_result : int big_array = [2; 3; 4; 1] in
-  //when
-  let result = Bigarray.rotate i lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-(**
- *  Remove
- *)
-let test_remove_with_int_should_work =
-  //Given
-  let lst1 : int big_array = [1; 2; 3; 2] in
-  let elem : int = 2 in
-  let intended_result : int big_array = [1; 3] in
-  //when
-  let result = Bigarray.remove elem lst1 in
-  //Then
-  let () = assert (result = intended_result) in "OK"
-
-
-
-// //  let () = Test.log ("result : ", result) in
+let test_rotate =
+  let xs = [1; 2; 3; 4; 5; 6; 7] in
+  let ys =
+    ["foo"; "bar"; "baz"; "qux"; "quux"; "corge"; "grault"] in
+  begin
+    assert (Bigarray.rotate xs 0 = xs);
+    assert (Bigarray.rotate xs 1 = [2 ; 3 ; 4 ; 5 ; 6 ; 7 ; 1]);
+    assert (Bigarray.rotate xs 4 = [5 ; 6 ; 7 ; 1; 2; 3; 4]);
+    assert (Bigarray.rotate ys 1 = ["bar"; "baz"; "qux"; "quux"; "corge"; "grault"; "foo"]);
+    assert (Bigarray.rotate ys 4 = ["quux"; "corge"; "grault"; "foo"; "bar"; "baz"; "qux"])
+  end


### PR DESCRIPTION
- idiomatic order of param: list first, then then getter, then replacing value
- idiomatic naming (type a, a list, xs...)
- used stable tag in the makefile
- inline annotation should not belong in the lib, because it can easilly be added by making an alias, but it can't be removed
- use `_exn` suffix when function may throw a failwith

concerned about the naming of this lib, isn't it more about list helpers?